### PR TITLE
feat(performance): Ensure requests use GET where possible

### DIFF
--- a/packages/api-client/src/helpers/magentoLink/graphQl.ts
+++ b/packages/api-client/src/helpers/magentoLink/graphQl.ts
@@ -50,7 +50,7 @@ export const apolloLinkFactory = (settings: Config, handlers?: {
       ...headers,
     },
   }));
-  const httpLink = createHttpLink({ uri: settings.api, fetch });
+  const httpLink = createHttpLink({ useGETForQueries: true, uri: settings.api, fetch });
 
   const onErrorLink = createErrorHandler();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
POST avoids cache without some POST varnish caching configuration and magento code changes to expose such headers. Easier to transform to GET where possible.

## Related Issue
FOCUS-295
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Site slow, needed site fast.

## How Has This Been Tested?
I used ngrok to proxy requests to Magento with this setting change and was able to observe appropriate behavior when requesting customer private endpoints (with authorization header), and stateless GET requests.

<img width="594" alt="CleanShot 2021-08-07 at 06 35 33@2x" src="https://user-images.githubusercontent.com/183880/128597356-e0cfaccc-89b2-46f2-bd1b-5c6e7a1cbe45.png">
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
