### PR TITLE
feat(FOCUS-539): Added split order to request

### DIFF
--- a/packages/api-client/src/api/placeOrder/placeOrder.ts
+++ b/packages/api-client/src/api/placeOrder/placeOrder.ts
@@ -5,6 +5,7 @@ mutation placeOrder($input: PlaceOrderInput) {
   placeOrder(input: $input) {
     order {
       order_number
+      split_order_numbers
     }
   }
 }`;


### PR DESCRIPTION
Added "split_order_number" field.

## Description
Added "split_order_number" field to "placeOrder" request.

## Related Issue
https://absolutewebservices.atlassian.net/browse/FOCUS-539

## Motivation and Context
Ability to get all the split orders numbers

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
